### PR TITLE
Resolve #46 - Image Scaling

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -201,7 +201,7 @@
 				var finalImage = Utils.getVirtualSEM_KonvaImage(stageFinal);
 				
 				// export the image
-				var url = finalImage.toDataURL({pixelRatio:2});
+				var url = finalImage.toDataURL({pixelRatio:1});
 				var filename = Utils.GetSuggestedFileName("result_image",++G_Export_img_count);
 				Utils.downloadURI(url, filename);
 			}

--- a/app/index.html
+++ b/app/index.html
@@ -192,12 +192,12 @@
 
 			// used to auto-name the export files with a counter
 			var G_Export_img_count = 0;
-			var stageFinal = G_STAGES[G_STAGES.length - 1];
 			function exportResultImage(){
 				// Export image as file download
 				// https://konvajs.org/docs/data_and_serialization/High-Quality-Export.html
 
 				// get the image without the row/draw indicator
+				var stageFinal = G_STAGES[G_STAGES.length - 1];
 				var finalImage = Utils.getVirtualSEM_KonvaImage(stageFinal);
 				
 				// export the image

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -1064,11 +1064,10 @@ function drawVirtualSEM(stage, beam, subregionRect, subregionRectStage, original
 			fullImgWidthNm / cols,
 			fullImgWidthNm / rows,
 		);
-		var displayUnit = fmtPxSize.unit + "/px";
 		Utils.updateExtraInfo(stage, cols + ' x ' + rows
 			+ ' px<br>' + fmtPxSize.value.toFixed(G_MATH_TOFIXED.SHORT)
 			+ " x " + fmtPxSize.value2.toFixed(G_MATH_TOFIXED.SHORT)
-			+ " " + displayUnit);
+			+ " " + fmtPxSize.unit + "/px");
 	};
 	updateConfigValues();
 

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -231,8 +231,8 @@ function drawSubregionImage(stage, oImg, size, updateCallback = null) {
 		console.log("img natural size:", oImg.naturalWidth, oImg.naturalHeight);
 	
 	// image ratio to "fit" in canvas
-	var doFill = Utils.getImageIsFillMode();
-	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
+	var fillMode = Utils.getImageFillMode();
+	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, fillMode);
 
 	var minScale = {
 		x: fitSize.w / oImg.naturalWidth,
@@ -357,8 +357,8 @@ function drawSpotContent(stage, sImage, sBeam, updateCallback = null) {
 	var _tempCellSize = Utils.computeCellSize(sImage);
 	var initialSpotScale = sBeam.width() / _tempCellSize.w;
 	// get image proportions once scaled and fitted in the stages
-	var max = G_BOX_SIZE, oImg = sImage.image(), doFill = Utils.getImageIsFillMode();
-	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
+	var max = G_BOX_SIZE, oImg = sImage.image(), fillMode = Utils.getImageFillMode();
+	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, fillMode);
 	var minScaleX = fitSize.w / oImg.naturalWidth;
 	// center the image copy based on the calculated center and initial scales
 	Utils.scaleOnCenter(stage, image, minScaleX, initialSpotScale);
@@ -760,7 +760,8 @@ function drawResampled(sourceStage, destStage, originalImage, spotScale, sBeam) 
  */
 function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZE, updateCallback = null){
 
-	var fit = Utils.fitImageProportions(imageObj.naturalWidth, imageObj.naturalHeight, maxSize);
+	var fillMode = Utils.getImageFillMode();
+	var fit = Utils.fitImageProportions(imageObj.naturalWidth, imageObj.naturalHeight, maxSize, fillMode);
 
 	var layer = stage.getLayers()[0];
 	layer.destroyChildren(); // avoid memory leaks

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -871,9 +871,8 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 			// x: (image.x() - si.x()) / si.scaleX(),
 			// y: (image.y() - si.y()) / si.scaleY(),
 
-			// new working ?
-			x: (image.x() - si.x()) / (si.scaleX() / (image.width() / imageObj.naturalWidth)),
-			y: (image.y() - si.y()) / (si.scaleY() / (image.height() / imageObj.naturalHeight)),
+			x: ((image.x() - si.x()) / si.scaleX()) * (image.width() / imageObj.naturalWidth),
+			y: ((image.y() - si.y()) / si.scaleY()) * (image.height() / imageObj.naturalHeight),
 		});
 
 		var coords = Utils.stageToUnitCoordinates(image.x(), image.y(), stage);
@@ -883,17 +882,9 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 			// width: si.width() / si.scaleX(),
 			// height: si.height() / si.scaleY(),
 
-			// new working
-			// width: image.width() / (si.scaleX() / (stage.width() / imageObj.naturalWidth)),
-			// height: image.height() / (si.scaleY() / (stage.height() / imageObj.naturalHeight)),
-			
 			// also working ?
-			// width: image.width() / (si.scaleX() / (image.width() / imageObj.naturalWidth)),
-			// height: image.height() / (si.scaleY() / (image.height() / imageObj.naturalHeight)),
-
-			// also working ?
-			width: (image.width() * stage.width()) / (si.scaleX() * imageObj.naturalWidth),
-			height: (image.height() * stage.height()) / (si.scaleY() * imageObj.naturalHeight),
+			width: (stage.width() / si.scaleX()) * (image.width() / imageObj.naturalWidth),
+			height: (stage.height() / si.scaleY()) * (image.height() / imageObj.naturalHeight),
 		});
 		// console.log(rect.size());
 		// console.log(image.width(), si.scaleX(), image.width(), imageObj.naturalWidth);

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -447,10 +447,8 @@ function drawProbeLayout(drawStage, baseImage, spotScale, beam) {
 	var baseLayer = layers[0];
 	baseLayer.destroyChildren(); // avoid memory leaks
 
-	// old broken, was wrong?
-	// var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
-	// new working? maybe should have just used stage rect instead of image rect?
-	var baseGridRect = drawStage;
+	// The subregion area is based on what is "visible" in the subregion view.
+	var baseGridRect = Utils.getRectFromKonvaObject(baseImage.getStage());
 	
 	var imageCopy = baseImage.clone();
 
@@ -567,10 +565,8 @@ function drawProbeLayoutSampling(drawStage, originalImage, spotScale, sBeam) {
 	var drawLayer = drawStage.getLayers()[0];
 	drawLayer.destroyChildren(); // avoid memory leaks
 
-	// old broken, was wrong?
-	// var baseGridRect = new Konva.Rect(imageCopy.getSelfRect());
-	// new working? maybe should have just use stage size
-	var baseGridRect = drawStage;
+	// The subregion area is based on what is "visible" in the subregion view.
+	var baseGridRect = Utils.getRectFromKonvaObject(originalImage.getStage());
 
 	// setup "last" values to help optimize for draw performance
 	// similar reason as for drawProbeLayout()
@@ -651,10 +647,8 @@ function drawResampled(sourceStage, destStage, originalImage, spotScale, sBeam) 
 	var baseImage = originalImage; //.clone();
 	var beam = sBeam; //.clone();
 
-	// old broken?
-	// var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
-	// new working, maybe should just have used stage size instead?
-	var baseGridRect = destStage;
+	// The subregion area is based on what is "visible" in the subregion view.
+	var baseGridRect = Utils.getRectFromKonvaObject(baseImage.getStage());
 
 	var rows = 0, cols = 0;
 	var probe = null;

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -123,8 +123,8 @@ function drawSpotProfileEdit(stage, updateCallback = null) {
 	var container = stage.container();
 	// make it focusable
 	container.tabIndex = 2;
-	// avoid addEventListener, since this is a simple and we only want one handler
-	// and replace it when a new image is loaded
+	// Avoiding using addEventListener, since we only ever want one handler at time.
+	// This way, we easily replace it when a new image is loaded.
 	container.onkeydown = function(e) {
 		// don't handle meta-key'd events for now...
 		const metaPressed = e.shiftKey || e.ctrlKey || e.metaKey;
@@ -302,8 +302,8 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 	var container = stage.container();
 	// make it focusable
 	container.tabIndex = 1;
-	// avoid addEventListener, since this is a simple and we only want one handler
-	// and replace it when a new image is loaded
+	// Avoiding using addEventListener, since we only ever want one handler at time.
+	// This way, we easily replace it when a new image is loaded.
 	container.onkeydown = function(e) {
 		// don't handle meta-key'd events for now...
 		const metaPressed = e.shiftKey || e.ctrlKey || e.metaKey;

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -219,20 +219,19 @@ function drawSpotProfileEdit(stage, updateCallback = null) {
  * @param {*} stage The stage to draw it on.
  * @param {*} oImg The ground truth image.
  * @param {Number} size (to be removed) The max size (width or height) of the image to draw.
- * @param {Boolean} doFill (to be removed?) Fill or letterbox mode to fit the image.
  * @param {Function} updateCallback 
  * @returns a reference to the subregion image object that can be panned and zoomed by the user.
  * 
  * @todo remove 'size' ... confusing and not useful.
- * @todo likely remove 'doFill' ... maybe confusing and not useful.
  */
-function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = null) {
+function drawSubregionImage(stage, oImg, size, updateCallback = null) {
 	var max = size;
 
 	if (G_DEBUG)
 		console.log("img natural size:", oImg.naturalWidth, oImg.naturalHeight);
 	
 	// image ratio to "fit" in canvas
+	var doFill = Utils.getImageIsFillMode();
 	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
 
 	var minScale = {

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -123,7 +123,9 @@ function drawSpotProfileEdit(stage, updateCallback = null) {
 	var container = stage.container();
 	// make it focusable
 	container.tabIndex = 2;
-	container.addEventListener('keydown', function(e) {
+	// avoid addEventListener, since this is a simple and we only want one handler
+	// and replace it when a new image is loaded
+	container.onkeydown = function(e) {
 		// don't handle meta-key'd events for now...
 		const metaPressed = e.shiftKey || e.ctrlKey || e.metaKey;
 		if (metaPressed)
@@ -145,7 +147,7 @@ function drawSpotProfileEdit(stage, updateCallback = null) {
 			default: break;
 		}
 		e.preventDefault();
-	});
+	};
 
 	// Replacing userScaledImage / userImage
 	// invisible shape to get scale X/Y as a control for spot size/mag
@@ -300,7 +302,9 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 	var container = stage.container();
 	// make it focusable
 	container.tabIndex = 1;
-	container.addEventListener('keydown', function(e) {
+	// avoid addEventListener, since this is a simple and we only want one handler
+	// and replace it when a new image is loaded
+	container.onkeydown = function(e) {
 		// don't handle meta-key'd events for now...
 		const metaPressed = e.shiftKey || e.ctrlKey || e.metaKey;
 		if (metaPressed)
@@ -319,7 +323,7 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 			default: break;
 		}
 		e.preventDefault();
-	});
+	};
 
 	return kImage;
 }

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -655,7 +655,10 @@ function drawResampled(sourceStage, destStage, originalImage, spotScale, sBeam) 
 	var baseImage = originalImage; //.clone();
 	var beam = sBeam; //.clone();
 
-	var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
+	// old broken?
+	// var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
+	// new working, maybe should just have used stage size instead?
+	var baseGridRect = destStage;
 
 	var rows = 0, cols = 0;
 	var probe = null;

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -230,12 +230,6 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 	if (G_DEBUG)
 		console.log("img natural size:", oImg.naturalWidth, oImg.naturalHeight);
 	
-	
-	var img_width = oImg.naturalWidth, img_height = oImg.naturalHeight;
-
-
-	var img_width = oImg.naturalWidth, img_height = oImg.naturalHeight;
-
 	// image ratio to "fit" in canvas
 	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
 
@@ -778,6 +772,8 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 		strokeScaleEnabled: false,
 	});
 
+	var imagePixelScaling = Utils.imagePixelScaling(image, imageObj);
+
 	// Draggable nav-rect
 	// https://github.com/joedf/ImgBeamer/issues/41
 	rect.on('dragmove', function(){
@@ -842,31 +838,22 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 		// update the subregion view to the new position and zoom based on changes
 		// to the nav-rect by the user
 		var si = subregionImage;
-		var imagePixelScaling = {
-			x: (image.width() / imageObj.naturalWidth),
-			y: (image.height() / imageObj.naturalHeight),
-		};
 
 		si.scale({
-			// old broken
-			// x: stage.width() / rect.width(),
-			// y: stage.height() / rect.height(),
 			x: (stage.width() / rect.width()) * imagePixelScaling.x,
 			y: (stage.height() / rect.height()) * imagePixelScaling.y,
 		});
-
+		
 		si.position({
-			// old broken
-			// x: (stage.x() - rect.x()) * si.scaleX(),
-			// y: (stage.y() - rect.y()) * si.scaleY(),
-			x: ((image.x() - rect.x()) / si.scaleX()) * imagePixelScaling.x,
-			y: ((image.y() - rect.y()) / si.scaleY()) * imagePixelScaling.y,
+			x: ((image.x() - rect.x()) * si.scaleX()) / imagePixelScaling.x,
+			y: ((image.y() - rect.y()) * si.scaleY()) / imagePixelScaling.y,
 		});
 
 		// this propagates the changes to the subregion to the rest of the app
-		// if (typeof updateCallback == 'function')
-		// 	return updateCallback();
+		if (typeof updateCallback == 'function')
+			return updateCallback();
 	};
+	
 	// Grab cursor for nav-rectangle overlay
 	// https://konvajs.org/docs/styling/Mouse_Cursor.html
 	layer.listening(true);
@@ -883,10 +870,6 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 		// calc location rect from subregionImage
 		// and update bounds drawn rectangle
 		var si = subregionImage;
-		var imagePixelScaling = {
-			x: (image.width() / imageObj.naturalWidth),
-			y: (image.height() / imageObj.naturalHeight),
-		};
 
 		rect.position({
 			x: ((image.x() - si.x()) / si.scaleX()) * imagePixelScaling.x,

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -235,13 +235,19 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 	// image ratio to "fit" in canvas
 	var fitSize = Utils.fitImageProportions(img_width, img_height, max, doFill);
 
+	var minScaleX = fitSize.w / img_width;
+
 	// TODO: this shouldnt be need or it at least duplicate with part of drawGroundtruthImage()
 	var kImage = new Konva.Image({
-		x: (max - fitSize.w)/2,
-		y: (max - fitSize.h)/2,
+		// x: (max - fitSize.w)/2,
+		// y: (max - fitSize.h)/2,
 		image: oImg,
-		width: fitSize.w, 
-		height: fitSize.h,
+		// width: fitSize.w,
+		// height: fitSize.h,
+		scale: {
+			x: minScaleX,
+			y: fitSize.h / img_height,
+		},
 		draggable: true,
 	});
 
@@ -285,7 +291,7 @@ function drawSubregionImage(stage, oImg, size, doFill = false, updateCallback = 
 
 		// callback here, e.g. doUpdate();
 		doUpdate();
-	}, G_ZOOM_FACTOR_PER_TICK, 1));
+	}, G_ZOOM_FACTOR_PER_TICK, minScaleX));
 
 	layer.add(kImage);
 
@@ -861,13 +867,36 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 		// and update bounds drawn rectangle
 		var si = subregionImage;
 		rect.position({
-			x: (image.x() - si.x()) / si.scaleX(),
-			y: (image.y() - si.y()) / si.scaleY(),
+			// old broken
+			// x: (image.x() - si.x()) / si.scaleX(),
+			// y: (image.y() - si.y()) / si.scaleY(),
+
+			// new working ?
+			x: (image.x() - si.x()) / (si.scaleX() / (image.width() / imageObj.naturalWidth)),
+			y: (image.y() - si.y()) / (si.scaleY() / (image.height() / imageObj.naturalHeight)),
 		});
+
+		var coords = Utils.stageToUnitCoordinates(image.x(), image.y(), stage);
+		// var coords2 = Utils.unitToImagePixelCoordinates()
 		rect.size({
-			width: si.width() / si.scaleX(),
-			height: si.height() / si.scaleY(),
+			// old, broken
+			// width: si.width() / si.scaleX(),
+			// height: si.height() / si.scaleY(),
+
+			// new working
+			// width: image.width() / (si.scaleX() / (stage.width() / imageObj.naturalWidth)),
+			// height: image.height() / (si.scaleY() / (stage.height() / imageObj.naturalHeight)),
+			
+			// also working ?
+			// width: image.width() / (si.scaleX() / (image.width() / imageObj.naturalWidth)),
+			// height: image.height() / (si.scaleY() / (image.height() / imageObj.naturalHeight)),
+
+			// also working ?
+			width: (image.width() * stage.width()) / (si.scaleX() * imageObj.naturalWidth),
+			height: (image.height() * stage.height()) / (si.scaleY() * imageObj.naturalHeight),
 		});
+		// console.log(rect.size());
+		// console.log(image.width(), si.scaleX(), image.width(), imageObj.naturalWidth);
 
 		// subregion overlay visibility
 		rect.visible(G_SHOW_SUBREGION_OVERLAY);
@@ -895,7 +924,7 @@ function drawGroundtruthImage(stage, imageObj, subregionImage, maxSize=G_BOX_SIZ
 		var fmtMiddle = Utils.formatUnitNm(middle.x, middle.y);
 
 		var sizeFOV = {
-			w: (rect.width() / stage.width()) * imageObj.width * pxSizeNm,
+			w: (rect.width() / stage.width()) * imageObj.naturalWidth * pxSizeNm,
 		};
 		var fmtSizeFOV = Utils.formatUnitNm(sizeFOV.w);
 

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -353,7 +353,19 @@ function drawSpotContent(stage, sImage, sBeam, updateCallback = null) {
 	// zoom/scale so that the spot size starts at 100%
 	var _tempCellWidth = sImage.width() / Utils.getColsInput();
 	var initialSpotScale = sBeam.width() / _tempCellWidth;
-	Utils.scaleOnCenter(stage, image, 1, initialSpotScale);
+	// old broken
+	// Utils.scaleOnCenter(stage, image, 1, initialSpotScale);
+	//new working?
+	var max = G_BOX_SIZE; // or stage.width(); //?
+	var oImg = sImage.image();
+	var doFill = false;
+	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
+	var minScale = {
+		x: fitSize.w / oImg.naturalWidth,
+		y: fitSize.h / oImg.naturalHeight,
+	};
+	// var imgPxScaling = Utils.imagePixelScaling(stage, sImage.image());
+	Utils.scaleOnCenter(stage, image, minScale.x, initialSpotScale);
 
 	layer.draw();
 

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -677,8 +677,6 @@ function drawResampled(sourceStage, destStage, originalImage, spotScale, sBeam) 
 		var layers = destStage.getLayers();
 		if (layers.length < 1) { destStage.add(new Konva.Layer({ listening: false })); }
 
-		// TODO: display pixel size in physical units and use Utils.formatUnitNm()
-
 		changeCount++;
 	};
 	

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -451,7 +451,10 @@ function drawProbeLayout(drawStage, baseImage, spotScale, beam) {
 	var baseLayer = layers[0];
 	baseLayer.destroyChildren(); // avoid memory leaks
 
-	var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
+	// old broken, was wrong?
+	// var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
+	// new working? should have been stage rect instead of image rect?
+	var baseGridRect = drawStage;
 	
 	var imageCopy = baseImage.clone();
 

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -453,7 +453,7 @@ function drawProbeLayout(drawStage, baseImage, spotScale, beam) {
 
 	// old broken, was wrong?
 	// var baseGridRect = new Konva.Rect(baseImage.getSelfRect());
-	// new working? should have been stage rect instead of image rect?
+	// new working? maybe should have just used stage rect instead of image rect?
 	var baseGridRect = drawStage;
 	
 	var imageCopy = baseImage.clone();
@@ -571,7 +571,10 @@ function drawProbeLayoutSampling(drawStage, originalImage, spotScale, sBeam) {
 	var drawLayer = drawStage.getLayers()[0];
 	drawLayer.destroyChildren(); // avoid memory leaks
 
-	var baseGridRect = new Konva.Rect(imageCopy.getSelfRect());
+	// old broken, was wrong?
+	// var baseGridRect = new Konva.Rect(imageCopy.getSelfRect());
+	// new working? maybe should have just use stage size
+	var baseGridRect = drawStage;
 
 	// setup "last" values to help optimize for draw performance
 	// similar reason as for drawProbeLayout()

--- a/app/src/drawsteps.js
+++ b/app/src/drawsteps.js
@@ -355,21 +355,14 @@ function drawSpotContent(stage, sImage, sBeam, updateCallback = null) {
 
 	// "pre-zoom" a bit, and start with center position
 	// zoom/scale so that the spot size starts at 100%
-	var _tempCellWidth = sImage.width() / Utils.getColsInput();
-	var initialSpotScale = sBeam.width() / _tempCellWidth;
-	// old broken
-	// Utils.scaleOnCenter(stage, image, 1, initialSpotScale);
-	//new working?
-	var max = G_BOX_SIZE; // or stage.width(); //?
-	var oImg = sImage.image();
-	var doFill = false;
+	var _tempCellSize = Utils.computeCellSize(sImage);
+	var initialSpotScale = sBeam.width() / _tempCellSize.w;
+	// get image proportions once scaled and fitted in the stages
+	var max = G_BOX_SIZE, oImg = sImage.image(), doFill = Utils.getImageIsFillMode();
 	var fitSize = Utils.fitImageProportions(oImg.naturalWidth, oImg.naturalHeight, max, doFill);
-	var minScale = {
-		x: fitSize.w / oImg.naturalWidth,
-		y: fitSize.h / oImg.naturalHeight,
-	};
-	// var imgPxScaling = Utils.imagePixelScaling(stage, sImage.image());
-	Utils.scaleOnCenter(stage, image, minScale.x, initialSpotScale);
+	var minScaleX = fitSize.w / oImg.naturalWidth;
+	// center the image copy based on the calculated center and initial scales
+	Utils.scaleOnCenter(stage, image, minScaleX, initialSpotScale);
 
 	layer.draw();
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -115,7 +115,7 @@ const nStages = 9;
 var G_STAGES = [];
 // first create the stages
 for (let i = 0; i < nStages; i++) {
-	var stage = Utils.newStageTemplate(G_MAIN_CONTAINER, G_BOX_SIZE, G_BOX_SIZE);
+	let stage = Utils.newStageTemplate(G_MAIN_CONTAINER, G_BOX_SIZE, G_BOX_SIZE);
 	G_STAGES.push(stage);
 }
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -184,7 +184,7 @@ function OnImageLoaded(eImg, stages){
 
 	var updateInfoDisplays = function(){
 		// update spot/beam info: size, rotation, shape
-		var cellSize = Utils.computeCellSize(subregionImage);
+		var cellSize = Utils.computeCellSize(subregionImage.getStage());
 		Utils.updateDisplayBeamParams(spotProfileStage, layoutBeam, cellSize, spotScaling, promptForSpotWidth);
 		Utils.updateMagInfo(baseImageStage, subregionImage);
 		Utils.updateSubregionPixelSize(resampledStage, subregionImage, eImg);

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -216,7 +216,7 @@ function OnImageLoaded(eImg, stages){
 		.attr('box_label', 'Subregion View / FOV')
 		.attr('note', 'Pan & Zoom: Drag and Scroll\nPress [R] to reset')
 		.css('border-color', 'blue');
-	var subregionImage = drawSubregionImage(baseImageStage, eImg, G_BOX_SIZE, false, doUpdate);
+	var subregionImage = drawSubregionImage(baseImageStage, eImg, G_BOX_SIZE, doUpdate);
 
 	// make a clone without copying over the event bindings
 	var image = subregionImage.clone().off();

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -218,9 +218,6 @@ function OnImageLoaded(eImg, stages){
 		.css('border-color', 'blue');
 	var subregionImage = drawSubregionImage(baseImageStage, eImg, G_BOX_SIZE, doUpdate);
 
-	// make a clone without copying over the event bindings
-	var image = subregionImage.clone().off();
-
 	// draw Spot Content
 	$(spotContentStage.getContainer())
 		.addClass('advancedMode')
@@ -228,7 +225,9 @@ function OnImageLoaded(eImg, stages){
 		.attr('box_label', 'Spot Content')
 		.attr('note', 'Scroll to adjust spot size\nHold [Shift] for half rate');
 	var spotContentBeam = beam.clone();
-	drawSpotContent(spotContentStage, image, spotContentBeam, doUpdate);
+	// make a clone without copying over the event bindings
+	var imageCopy = subregionImage.clone().off();
+	drawSpotContent(spotContentStage, imageCopy, spotContentBeam, doUpdate);
 
 	/**(temporary) publicly exposed function to set the spot width
 	 * @param {number} spotWidth the spot width in percent (%), ex. use 130 for 130%.

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -700,17 +700,22 @@ const Utils = {
 		var gt_stage_size = destStage.size();
 
 		var pxSizeNm = Utils.getPixelSizeNmInput();
-		var subregionSize = {
-			w: (gt_stage_size.width / rect.w) * (imageObj.naturalWidth * pxSizeNm),
-			h: (gt_stage_size.height / rect.h) * (imageObj.naturalHeight * pxSizeNm),
+		var fullImgSize = {
+			w: imageObj.naturalWidth * pxSizeNm,
+			h: imageObj.naturalHeight * pxSizeNm,
+		};
+		// similar formula to the used for the subregion rect in the groundtruth view
+		var subregionSizeNm = {
+			w: (gt_stage_size.width / rect.w) * fullImgSize.w,
+			h: (gt_stage_size.height / rect.h) * fullImgSize.h,
 		};
 
 		// get optimal / formated unit
 		// TODO: maybe use "this." instead of "Utils."
 		// do it for all functions too?
 		var fmtPxSize = Utils.formatUnitNm(
-			subregionSize.w / cols,
-			subregionSize.h / rows
+			subregionSizeNm.w / cols,
+			subregionSizeNm.h / rows
 		);
 
 		// display coords & FOV size

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -690,8 +690,8 @@ const Utils = {
 		var rows = Utils.getRowsInput(), cols = Utils.getColsInput();
 
 		var rect = {
-			w: subregionImage.width() / subregionImage.scaleX(),
-			h: subregionImage.height() / subregionImage.scaleY(),
+			w: subregionImage.width() * subregionImage.scaleX(),
+			h: subregionImage.height() * subregionImage.scaleY(),
 		};
 
 		// TODO: maybe get the ground truth image stage for the size info instead,
@@ -700,15 +700,18 @@ const Utils = {
 		var gt_stage_size = destStage.size();
 
 		var pxSizeNm = Utils.getPixelSizeNmInput();
-		var pxSize = {
-			w: ((rect.w / gt_stage_size.width) * (imageObj.width * pxSizeNm)) / cols,
-			h: ((rect.h / gt_stage_size.height) * (imageObj.height * pxSizeNm)) / rows,
+		var subregionSize = {
+			w: (gt_stage_size.width / rect.w) * (imageObj.naturalWidth * pxSizeNm),
+			h: (gt_stage_size.height / rect.h) * (imageObj.naturalHeight * pxSizeNm),
 		};
 
 		// get optimal / formated unit
 		// TODO: maybe use "this." instead of "Utils."
 		// do it for all functions too?
-		var fmtPxSize = Utils.formatUnitNm(pxSize.w, pxSize.h);
+		var fmtPxSize = Utils.formatUnitNm(
+			subregionSize.w / cols,
+			subregionSize.h / rows
+		);
 
 		// display coords & FOV size
 		Utils.updateExtraInfo(destStage,

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -504,24 +504,21 @@ const Utils = {
 	},
 
 	/**
-	 * Calculates cell size based on imageRect, rows and cols
-	 * @param {*} image the subregion image object.
-	 * @param {number} rows (optional) the number of rows to split the subregion into.
+	 * Calculates cell size based on given object (eg. rect, stage, or image), rows and cols
+	 * @param {*} rect a Konva object that has a width and height, usually a rect, image, or stage.
+	 * @param {number} rows (optional) the number of rows to split the area into.
 	 * If not is provided, attempts to get it from gui/input.
-	 * @param {number} cols (optional) the number of columns to split the subregion into.
+	 * @param {number} cols (optional) the number of columns to split the area into.
 	 * If not is provided, attempts to get it from gui/input.
 	 * @returns the size (w,h) of a cell in the raster grid.
 	 */
-	computeCellSize: function(image, rows = -1, cols = -1){
+	computeCellSize: function(rect, rows = -1, cols = -1){
 		if (rows <= 0) { rows = this.getRowsInput(); }
 		if (cols <= 0) { cols = this.getColsInput(); }
 
-		var stageSize = image.getStage().size();
-		// sorta fixed? was broken?, now working?
-		// maybe also update function doc / comment
 		var cellSize = {
-			w: (image.width() / cols) / (image.width() / stageSize.width),
-			h: (image.height() / rows) / (image.height() / stageSize.height),
+			w: rect.width() / cols,
+			h: rect.height() / rows,
 		};
 		return cellSize;
 	},

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -159,6 +159,11 @@ const Utils = {
 	getSpotLayoutOpacityInput: function(){ return G_GUI_Controller.previewOpacity; },
 	getImageMetricAlgorithm: function(){ return G_GUI_Controller.imageMetricAlgo; },
 	getImageSmoothing: function(){ return G_GUI_Controller.imageSmoothing; },
+	getImageIsFillMode: function(){
+		// TODO: maybe add a GUI option to toggle between fit, fill, stretch modes...
+		// just set as true for now, ie. use "fit" proportions
+		return true;
+	},
 
 	/**
 	 * Creates a Zoom event handler to be used on a stage.

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -993,10 +993,10 @@ const Utils = {
 		var stepSizeX = rect.width() / cols;
 		var stepSizeY = rect.height() / rows;
 	
-		const xSize= gridLayer.width(), // stage.width(), 
-				ySize= gridLayer.height(), // stage.height(),
-				xSteps = cols, //Math.round(xSize/ stepSizeX), 
-				ySteps = rows; //Math.round(ySize / stepSizeY);
+		const xSize = gridLayer.width(), // stage.width(), 
+			ySize = gridLayer.height(), // stage.height(),
+			xSteps = cols, //Math.round(xSize/ stepSizeX), 
+			ySteps = rows; //Math.round(ySize / stepSizeY);
 
 		// draw vertical lines
 		for (let i = 0; i <= xSteps; i++) {

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -513,14 +513,15 @@ const Utils = {
 	 * @returns the size (w,h) of a cell in the raster grid.
 	 */
 	computeCellSize: function(image, rows = -1, cols = -1){
-		var subregionRect = image.getSelfRect();
-
 		if (rows <= 0) { rows = this.getRowsInput(); }
 		if (cols <= 0) { cols = this.getColsInput(); }
 
+		var stageSize = image.getStage().size();
+		// sorta fixed? was broken?, now working?
+		// maybe also update function doc / comment
 		var cellSize = {
-			w: subregionRect.width / cols,
-			h: subregionRect.height / rows
+			w: (image.width() / cols) / (image.width() / stageSize.width),
+			h: (image.height() / rows) / (image.height() / stageSize.height),
 		};
 		return cellSize;
 	},

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -1633,6 +1633,20 @@ const Utils = {
 	},
 
 	/**
+	 * Creates a new Konva.Rect object based on the position and size of a given konva object.
+	 * @param {*} kObject A konva object that has a size and postion, such as a stage, image, or rect.
+	 * @returns a rectable object with x, y, width, and height functions.
+	 */
+	getRectFromKonvaObject: function(kObject){
+		return new Konva.Rect({
+			x: kObject.x(),
+			y: kObject.y(),
+			width: kObject.width(),
+			height: kObject.height(),
+		});
+	},
+
+	/**
 	 * Finds (non-recusrive) the first layer with a matching on a given stage, null if n/a.
 	 * @param {*} stage The stage or element with layers.
 	 * @param {*} layerName The name of the layer.

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -1321,6 +1321,19 @@ const Utils = {
 	},
 
 	/**
+	 * Gets the image scaling based on the Konva.Image size vs the image's true or 'natural' size.
+	 * @param {*} konvaImage The konva image object
+	 * @param {*} imageObj The actual image's HTML/DOM object
+	 * @returns 
+	 */
+	imagePixelScaling: function(konvaImage, imageObj) {
+		return {
+			x: (konvaImage.width() / imageObj.naturalWidth),
+			y: (konvaImage.height() / imageObj.naturalHeight),
+		};
+	},
+
+	/**
 	 * Convert stage to unit square coordinates
 	 * @param {*} x 
 	 * @param {*} y 

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -175,8 +175,8 @@ const Utils = {
 	 * @param {object} konvaObj the figure or object on the stage to change.
 	 * @param {function} callback a callback for when the zoom event handler is called.
 	 * @param {number} scaleFactor the scale factor per "tick"
-	 * @param {number} scaleMin the scale minimum allowed defined as a number or function.
-	 * @param {number} scaleMax the scale maximum allowed defined as a number or function.
+	 * @param {number|function} scaleMin the scale minimum allowed defined as a number or function.
+	 * @param {number|function} scaleMax the scale maximum allowed defined as a number or function.
 	 * @returns the created event handler
 	 */
 	// eslint-disable-next-line no-magic-numbers
@@ -845,11 +845,11 @@ const Utils = {
 	 * @param {number} w the original width
 	 * @param {number} h the original height
 	 * @param {number} maxDimension The largest dimension (whether width or height) to fit in.
-	 * @param {boolean} fillMode Whether to a fill-in fit, stretch/squish fit otherwise.
+	 * @param {boolean} fillMode Whether to do a "fill", "fit" / "letterbox", "crop", or "squish" fit.
 	 * @returns the new calculated size
-	 * @todo https://github.com/joedf/ImgBeamer/issues/7
+	 * @todo fillMode is not yet fully supported, see https://github.com/joedf/ImgBeamer/issues/7
 	 */
-	fitImageProportions: function(w, h, maxDimension, fillMode="fit"){
+	fitImageProportions: function(w, h, maxDimension, fillMode="squish"){
 		var mode = fillMode.toLowerCase().trim();
 
 		// image ratio to "fit" in canvas

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -163,8 +163,9 @@ const Utils = {
 		// TODO: maybe add a GUI option to toggle between fit, fill, stretch modes...
 		// just a default for now, until support for this is implemented
 		// https://github.com/joedf/ImgBeamer/issues/7
-		// return "squish";
-		return "fit";
+		
+		// return "fit";
+		return "squish";
 	},
 
 		/**

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -1350,8 +1350,8 @@ const Utils = {
 	 */
 	unitToImagePixelCoordinates: function(x, y, imageObj) {
 		return {
-			x: x * imageObj.width,
-			y: y * imageObj.height,
+			x: x * imageObj.naturalWidth,
+			y: y * imageObj.naturalHeight,
 		};
 	},
 

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -159,26 +159,27 @@ const Utils = {
 	getSpotLayoutOpacityInput: function(){ return G_GUI_Controller.previewOpacity; },
 	getImageMetricAlgorithm: function(){ return G_GUI_Controller.imageMetricAlgo; },
 	getImageSmoothing: function(){ return G_GUI_Controller.imageSmoothing; },
-	getImageIsFillMode: function(){
+	getImageFillMode: function(){
 		// TODO: maybe add a GUI option to toggle between fit, fill, stretch modes...
-		// just set as true for now, ie. use "fit" proportions
-		return true;
+		// just a default for now, until support for this is implemented
+		// https://github.com/joedf/ImgBeamer/issues/7
+		// return "squish";
+		return "fit";
 	},
 
-	/**
+		/**
 	 * Creates a Zoom event handler to be used on a stage.
 	 * Holding the shift key scales at half the rate.
 	 * @param {object} stage the drawing stage
-	 * @param {*} konvaObj the figure or object on the stage to change.
-	 * @param {*} callback a callback for when the zoom event handler is called.
-	 * @param {*} scaleFactor the scale factor per "tick"
-	 * @param {number|function} scaleMin the scale minimum allowed defined as a number or function.
-	 * @param {number|function} scaleMax the scale maximum allowed defined as a number or function.
+	 * @param {object} konvaObj the figure or object on the stage to change.
+	 * @param {function} callback a callback for when the zoom event handler is called.
+	 * @param {number} scaleFactor the scale factor per "tick"
+	 * @param {number} scaleMin the scale minimum allowed defined as a number or function.
+	 * @param {number} scaleMax the scale maximum allowed defined as a number or function.
 	 * @returns the created event handler
 	 */
 	// eslint-disable-next-line no-magic-numbers
-	MakeZoomHandler: function(stage, konvaObj, callback=null, scaleFactor=1.2, scaleMin=0, scaleMax=Infinity)
-	{
+	MakeZoomHandler: function(stage, konvaObj, callback=null, scaleFactor=1.2, scaleMin=0, scaleMax=Infinity){
 		var _self = this;
 		var handler = function(e){
 			// modified from https://konvajs.org/docs/sandbox/Zooming_Relative_To_Pointer.html 
@@ -843,14 +844,20 @@ const Utils = {
 	 * @param {number} w the original width
 	 * @param {number} h the original height
 	 * @param {number} maxDimension The largest dimension (whether width or height) to fit in.
-	 * @param {boolean} doFill Whether to a fill-in fit or do a stretch fit otherwise.
+	 * @param {boolean} fillMode Whether to a fill-in fit, stretch/squish fit otherwise.
 	 * @returns the new calculated size
+	 * @todo https://github.com/joedf/ImgBeamer/issues/7
 	 */
-	fitImageProportions: function(w, h, maxDimension, doFill=false){
+	fitImageProportions: function(w, h, maxDimension, fillMode="fit"){
+		var mode = fillMode.toLowerCase().trim();
+
 		// image ratio to "fit" in canvas
 		var ratio = (w > h ? (w / maxDimension) : (h / maxDimension)); // fit
-		if (doFill){
+		if (mode == "fill"){
 			ratio = (w > h ? (h / maxDimension) : (w / maxDimension)); // fill
+		}
+		if (mode == "squish") {
+			// do nothing for now...
 		}
 
 		var iw = w/ratio; //, ih = h/ratio;


### PR DESCRIPTION
# Summary of changes
- Position and scale calculations now have to explicitly consider original image size
- Zooming in is now clearer for large/high-resolution images
- Gets rid of extra anti-aliasing as a by-product from down-scaling
- fix and use "squish" mode as default
- bugfix: prevent event doubling for [R] keypresses, would break when changing the input image
- change export `pixelRatio` to `1`, no real benefit to use `2` at the moment.
- some code clean up

# Screenshots
## Before
![image](https://github.com/joedf/ImgBeamer/assets/3848219/53846f02-6a98-4e87-b8e1-9f30edcf6113)
## After
![image](https://github.com/joedf/ImgBeamer/assets/3848219/16b8b068-a500-48b2-8da3-29bc90d9774b)
